### PR TITLE
Add support for custom pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ module.exports = {
 };
 ```
 
+### Options
+
+The loader accepts the following options:
+
+- `options.pragma` (default: `React.createElement`)
+  Pragma for JSX. e.g. A `pragma` of `h` will compile `<Elem />` to `h(Elem, {})`.
+- `options.pragmaImportSource` (default: `react`)
+  Where to import the pragma from.
+
 ## Contributing
 
 We welcome contributions to Storybook!

--- a/loader.js
+++ b/loader.js
@@ -1,8 +1,8 @@
 const { getOptions } = require('loader-utils');
 const { compile } = require('./compiler');
 
-const DEFAULT_RENDERER = `
-import React from 'react';
+const renderer = (importStr, importSrc) => `
+import ${importStr} from '${importSrc}';
 `;
 
 // Lifted from MDXv1 loader
@@ -18,6 +18,8 @@ const loader = async function (content) {
   const options = Object.assign({}, queryOptions, {
     filepath: this.resourcePath,
   });
+  const importSrc = options.pragmaImportSource || 'react';
+  const importStr = options.pragma ? `{ createElement as ${options.pragma} }` : 'React';
 
   let result;
   try {
@@ -26,7 +28,7 @@ const loader = async function (content) {
     return callback(err);
   }
 
-  const code = `${DEFAULT_RENDERER}\n${result}`;
+  const code = `${renderer(importStr, importSrc)}\n${result}`;
   return callback(null, code);
 };
 


### PR DESCRIPTION
Issue: #9

## What Changed

New options have been added to use a custom pragma. (Such as `h()` instead or `React.createElement()`.)
- `options.pragma` (default: `React.createElement`)
- `options.pragmaImportSource` (default: `react`)

## How to test

I'm not certain. I've tested this in my own set-up and I've run the unit test suite.

That said, I'm not sure whether the unit tests cover `loader.js`.

## Change Type

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
