### PR TITLE
Take remarkPlugins into account for this loader

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -1,6 +1,6 @@
 const { plugin, postprocess } = require('./dist/cjs');
 
-const compileAsync = async (code, { skipCsf }) => {
+const compileAsync = async (code, { remarkPlugins, skipCsf }) => {
   // This async import is needed because these libraries are ESM
   // and this file is CJS. Furthermore, we keep this file out of
   // the src directory so that babel doesn't turn these into `require`
@@ -11,6 +11,7 @@ const compileAsync = async (code, { skipCsf }) => {
   const store = { exports: '', toEstree };
   const rehypePlugins = skipCsf ? undefined : [[plugin, store]];
   const output = await compile(code, {
+    remarkPlugins,
     rehypePlugins,
     providerImportSource: '@mdx-js/react',
   });


### PR DESCRIPTION
Storybook composes multiple remark plugins that need to be forwarded to the compiler. This does not completely fix #11 but at least makes sure when the options make it across to the loader properly they will be applied to the compiled MDX.
