### PR TITLE
Add @mdx-js/react to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/generator": "^7.12.11",
     "@babel/parser": "^7.12.11",
     "@mdx-js/mdx": "^2.0.0",
+    "@mdx-js/react": "^2.0.0",
     "estree-to-babel": "^4.9.0",
     "hast-util-to-estree": "^2.0.2",
     "js-string-escape": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,6 +2142,14 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.6.22.tgz#ae09b4744fddc74714ee9f9d6f17a66e77c43573"
   integrity sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==
 
+"@mdx-js/react@^2.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-2.1.2.tgz#02972f170cd3ad9113ce448245c5f636bb3e750d"
+  integrity sha512-52e3DTJBrjsw3U51ZCdZ3N1IBaqnbzLIngCSXpKtiYiGr7PIqp3/P/+kym0MPTwBL/y9ZBmCieD8FyrXuEDrRw==
+  dependencies:
+    "@types/mdx" "^2.0.0"
+    "@types/react" ">=16"
+
 "@mdx-js/util@1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
@@ -3711,6 +3719,15 @@
   version "17.0.39"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
   integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16":
+  version "18.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.14.tgz#e016616ffff51dba01b04945610fe3671fdbe06d"
+  integrity sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
Issue: https://github.com/storybookjs/builder-vite/issues/421

Side question: Do we also need to support `@mdx-js/preact`, or is mdx in storybook always rendered with react?

## What Changed

Added @mdx-js/react@2 to dependencies.

## How to test

Hmmmm, not sure actually.  But adding this dependency to my own storybook project fixed my issues, and it's referenced in this project in: https://github.com/storybookjs/mdx2-csf/blob/d60715155ff6051c866b95275499e253c8c592db/compiler.js#L15

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
