### PR TITLE
Add debug output to `loader.js`

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -23,6 +23,7 @@ const loader = async function (content) {
   try {
     result = await compile(content, options);
   } catch (err) {
+    console.error('Error loading:', this.resourcePath)
     return callback(err);
   }
 


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->

Was almost impossible to debug where the loader errors were coming from when upgrading storybook with mdx2, until I monkey patched it with this change.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [x] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
