### PR TITLE
Remove JSX from compiler output

### DIFF
--- a/src/mdx2.test.ts
+++ b/src/mdx2.test.ts
@@ -100,7 +100,7 @@ describe('mdx2', () => {
       componentMeta.parameters = componentMeta.parameters || {};
       componentMeta.parameters.docs = {
         ...(componentMeta.parameters.docs || {}),
-        page: () => _jsx(MDXContent, {}),
+        page: MDXContent,
       };
 
       export default componentMeta;

--- a/src/mdx2.test.ts
+++ b/src/mdx2.test.ts
@@ -100,7 +100,7 @@ describe('mdx2', () => {
       componentMeta.parameters = componentMeta.parameters || {};
       componentMeta.parameters.docs = {
         ...(componentMeta.parameters.docs || {}),
-        page: () => <MDXContent />,
+        page: () => _jsx(MDXContent, {}),
       };
 
       export default componentMeta;

--- a/src/sb-mdx-plugin.ts
+++ b/src/sb-mdx-plugin.ts
@@ -318,7 +318,7 @@ export const wrapperJs = `
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   ...(componentMeta.parameters.docs || {}),
-  page: () => _jsx(MDXContent, {}),
+  page: MDXContent,
 };
 `.trim();
 

--- a/src/sb-mdx-plugin.ts
+++ b/src/sb-mdx-plugin.ts
@@ -318,7 +318,7 @@ export const wrapperJs = `
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   ...(componentMeta.parameters.docs || {}),
-  page: () => <MDXContent />,
+  page: () => _jsx(MDXContent, {}),
 };
 `.trim();
 


### PR DESCRIPTION
Issue: N/A

Returning JSX syntax from the mdx transform is problematic for the vite builder.  Previously, we added the `@vitejs/plugin-react` plugin to all non-react projects, so that we could use it to process the JSX being returned by this mdx compiler.  The `@mdxjs/mdx` compiler does not use JSX syntax, but rather uses the jsx runtime, by adding this to the top of the transformed code:

```
/*@jsxRuntime automatic @jsxImportSource react*/
import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
```

## What Changed

Instead of returning JSX syntax, I used the `MDXContent` directly as the component.

With this change, I was able to remove the react vite plugin from non-react frameworks, and still render the introduction mdx and docs pages in the example docs.  There may be other cases I haven't considered, though, like `.stories.mdx` files (are those still a thing?).

So, I'm not positive if this is a safe change, or if more is needed as well, but I wanted to at least start a discussion about it and see what happens in CI.

## How to test

I tested by making this change in the `node_modules` of a sandbox, and then starting up storybook.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.4-canary.20.5648a54.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/mdx2-csf@0.0.4-canary.20.5648a54.0
  # or 
  yarn add @storybook/mdx2-csf@0.0.4-canary.20.5648a54.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
