### PR TITLE
Bump version of loader-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "loader-utils": "^2.0.0"
+    "loader-utils": "^2.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",


### PR DESCRIPTION
Because of two security vulnerabilities:

CVE-2022-37599
CVE-2022-37603

There's probably no attack vector here (that is relevant for Storybook) but security scanning tools complain about this version of loader-utils.

## How to test

Run automated test suite

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
