### PR TITLE
Only support webpack 5, expose some types

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,4 +1,3 @@
-const { getOptions } = require('loader-utils');
 const { compile } = require('./dist/index');
 
 // FIXME: we shouldn't be doing this, but we need it
@@ -21,9 +20,7 @@ import React from 'react';
 // - MDX compiler built in
 const loader = async function (content) {
   const callback = this.async();
-  // this.getOptions() is webpack5 only
-  const queryOptions = this.getOptions ? this.getOptions() : getOptions(this);
-  const options = Object.assign({}, queryOptions, {
+  const options = Object.assign({}, this.getOptions(), {
     filepath: this.resourcePath,
   });
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
     "prettier": "prettier",
     "prepare": "husky install"
   },
-  "dependencies": {
-    "loader-utils": "^2.0.4"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,10 @@ import {
   wrapperJs,
   stringifyMeta,
 } from './sb-mdx-plugin';
-import { CompileOptions, MdxCompileOptions } from './types';
+import type { CompileOptions, MdxCompileOptions, JSXOptions } from './types';
 import { transformJSXAsync, transformJSXSync } from './jsx';
+
+export type { CompileOptions, MdxCompileOptions, JSXOptions };
 
 export const SEPARATOR = '/* ========= */';
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,2 +1,1 @@
 declare module 'estree-to-babel';
-declare module 'loader-utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9117,15 +9117,6 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
-  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
-
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"


### PR DESCRIPTION
Issue: #

## What Changed

We lost https://github.com/storybookjs/mdx2-csf/pull/28 in https://github.com/storybookjs/mdx2-csf/pull/30, so this re-exports a few types that are useful when interacting with this package.  It will be useful to avoid duplicating the types here: https://github.com/storybookjs/storybook/pull/20271/files#diff-e3d50a086df937d7c8f41d5819f0e6d8368961c112866cc291cfe057a4fafe23R10

It also removes some logic that was supporting webpack 4.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.4-canary.32.e03c3aa.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/mdx2-csf@0.0.4-canary.32.e03c3aa.0
  # or 
  yarn add @storybook/mdx2-csf@0.0.4-canary.32.e03c3aa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
