### PR TITLE
Fix type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,10 +79,14 @@
     "tsup": "^6.2.2",
     "typescript": "^4.2.4"
   },
+  "resolutions": {
+    "@types/estree": "1.0.0"
+  },
   "lint-staged": {
     "*.{ts,js,css,md}": "prettier --write"
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "packageManager": "yarn@1.22.9"
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig([
     format: 'esm',
     dts: {
       entry: ['./src/index.ts'],
+      resolve: true,
     },
     esbuildOptions(options, context) {
       options.platform = 'node';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,20 +4000,10 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/estree@*", "@types/estree@^0.0.51":
-  version "0.0.51"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
-  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
-
-"@types/estree@^0.0.46":
-  version "0.0.46"
-  resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
-  integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
-
-"@types/estree@^0.0.50":
-  version "0.0.50"
-  resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
-  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+"@types/estree@*", "@types/estree@1.0.0", "@types/estree@^0.0.46", "@types/estree@^0.0.50", "@types/estree@^0.0.51":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
+  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
 
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.31"


### PR DESCRIPTION
Issue: #29

## What Changed

<!-- Insert a description below. -->

Enables bundling types and resolves `@types/estree` so BaseNode can be exported.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

Tested this in https://github.com/storybookjs/storybook/pull/20116, and it worked as expected.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
