### PR TITLE
chore: backport mdx compiler options overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ const output = await compile(code);
 
 In addition, this library supports a simple Webpack loader that mirrors MDXv1's loader, but adds Webpack5 support. It doesn't use MDXv2's loader because it is prohibitively complex, and we want this to be interchangeable with the `@storybook/mdx1-csf`'s loader which is also based on the MDXv1 loader.
 
+The loader takes two options:
+
+- `skipCsf` don't generate CSF stories for the MDX file
+- `mdxCompileOptions` full options for the [MDX compile function](https://mdxjs.com/packages/mdx/#api)
+
+For example, to add [GFM support](https://mdxjs.com/guides/gfm/):
+
 ```js
+import remarkGfm from 'remark-gfm';
+
 module.exports = {
   module: {
     rules: [
@@ -55,7 +64,12 @@ module.exports = {
         use: [
           {
             loader: require.resolve('@storybook/mdx2-csf/loader'),
-            options: {},
+            options: {
+              skipCsf: false,
+              mdxCompileOptions: {
+                remarkPlugins: [remarkGfm],
+              },
+            },
           },
         ],
       },

--- a/compiler.js
+++ b/compiler.js
@@ -1,6 +1,6 @@
 const { plugin, postprocess } = require('./dist/cjs');
 
-const compileAsync = async (code, { skipCsf }) => {
+const compileAsync = async (code, { skipCsf, mdxCompileOptions }) => {
   // This async import is needed because these libraries are ESM
   // and this file is CJS. Furthermore, we keep this file out of
   // the src directory so that babel doesn't turn these into `require`
@@ -11,6 +11,7 @@ const compileAsync = async (code, { skipCsf }) => {
   const store = { exports: '', toEstree };
   const rehypePlugins = skipCsf ? undefined : [[plugin, store]];
   const output = await compile(code, {
+    ...mdxCompileOptions,
     rehypePlugins,
     providerImportSource: '@mdx-js/react',
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/mdx2-csf",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "MDXv2 to CSF webpack compiler and loader",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Issue: #

## What Changed

- Allows MDX compiler options to be passed through loader
- Bumps version

## How to test

- yalc

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [x] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
