### PR TITLE
Refactor rehypePlugins configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -212,9 +212,8 @@ function getCompilerOptionsAndContext(
   return {
     options: {
       providerImportSource: '@mdx-js/react',
-      rehypePlugins: [[plugin, context]],
       ...mdxCompileOptions,
-
+      rehypePlugins: [...(mdxCompileOptions?.rehypePlugins || []), [plugin, context]],
       // preserve the JSX, we'll deal with it using babel
       jsx: true,
     },


### PR DESCRIPTION
Issue: #41 

## What Changed

<!-- Insert a description below. -->
The mdxCompilerOptions are overriding everything at [storybookjs/mdx2-csf@next/src/index.ts#L215-L216](https://github.com/storybookjs/mdx2-csf/blob/next/src/index.ts?rgh-link-date=2023-04-04T13%3A00%3A18Z#L215-L216), This MR defines the rehypePlugins below instead, as a concatenation of the required and any user supplied ones.

## How to test

1. yarn build in the mdx2-csf repo
2. copy the dist folder from mdx2-csf into your sandbox at <SANDBOX_PATH>/node_modules/@storybook/mdx2-csf/dist
3. create the sandbox and test

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [x] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
